### PR TITLE
make commit & version steps optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ build-changelog := (folder: String | {
     major?: Boolean,
     patch?: Boolean,
     filename?: String,
+    commit?: Boolean,
+    version?: Boolean,
     logFlags?: String
 }, cb: Callback<err: Error, nextVersion: String>)
 ```
@@ -181,6 +183,21 @@ This flag defaults to `false`. When set to `true` the major
 This flag defaults to `false`. When set to `true` the patch
   version number will be increased instead of the minor version
   number.
+
+#### `opts.commit`
+
+This flag defaults to `true`. When it is set to `false` the 
+  committing steps will be skipped by `build-changelog`.
+
+This allows the user to create their own commits / tags.
+
+#### `opts.version`
+
+This flag defaults to `true`. When it is set to `false` the
+  version incrementing steps will be skipped by `build-changelog`
+
+This allows the user to increment & manager their version 
+  changes differently from their CHANGELOG changes
 
 #### `options.logFlags`
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,10 +18,6 @@ function printHelp() {
 }
 
 function main(opts) {
-    if (opts.h || opts.help) {
-        return printHelp();
-    }
-
     var command = opts._[0];
 
     if (!opts.folder) {
@@ -30,6 +26,22 @@ function main(opts) {
 
     if (opts['log-flags']) {
         opts.logFlags = opts['log-flags'];
+    }
+
+    if (!('commit' in opts)) {
+        opts.commit = true;
+    }
+
+    if (!('version' in opts)) {
+        opts.version = true;
+    }
+
+    if (opts['next-version']) {
+        opts.nextVersion = opts['next-version'];
+    }
+
+    if (opts.h || opts.help) {
+        return printHelp();
     }
 
     if (command === 'read') {

--- a/bin/usage.md
+++ b/bin/usage.md
@@ -4,15 +4,21 @@ Builds the CHANGELOG file and commits it to git. Either creates
   a new CHANGELOG file or appends to the top of an existing one.
 
 Options:
-    --major            bump the major version number
-    --log-flags=[str]  extra flags to pass to `git log`
-    --folder=[str]     sets the git repo & CHANGELOG location
-    --filename=[str]   the filename we write the CHANGELOG too
+    --major               bump the major version number
+    --log-flags=[str]     extra flags to pass to `git log`
+    --folder=[str]        sets the git repo & CHANGELOG location
+    --filename=[str]      the filename we write the CHANGELOG to
+    --no-commit           skip the committing & tagging step
+    --no-version          skip the version incrementing step
+    --next-version=[str]  specify the new version to be set
 
  - `--major` defaults to `false`
  - `--log-flags` defaults to `--decorate --oneline`
  - `--folder` defaults to `process.cwd()`
  - `--filename` defaults to `CHANGELOG`
+ - `--commit` defaults to `true`
+ - `--version` defaults to `true`
+ - `--next-version` defaults to `null`
 
 ## `build-changelog --help`
 

--- a/docs.mli
+++ b/docs.mli
@@ -74,5 +74,7 @@ build-changelog := (folder: String | {
     major?: Boolean,
     patch?: Boolean,
     filename?: String,
+    commit?: Boolean,
+    version?: Boolean,
     logFlags?: String
 }, cb: Callback<err: Error, nextVersion: String>)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,13 @@ var defaults = {
     nextVersion: null
 };
 
+/* Invoke the following in order
+
+ - `updateVersion()` if `opts.version` is not set to `false`
+ - `updateChangelog()`
+ - `commitChanges()` if `opts.commit` is not set to false
+ - return `nextVersion`
+*/
 function main(opts, cb) {
     if (typeof opts === 'string') {
         opts = { folder: opts };


### PR DESCRIPTION
This will make `build-changelog` less opinionated as you can turn said opinion off.
