### PR TITLE
make the cmd in the help format configurable

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,7 +29,7 @@ function main(opts) {
     var command = opts._[0];
 
     if (opts.h || opts.help || command === 'help') {
-        return printHelp();
+        return printHelp(opts);
     }
 
     if (!opts.folder) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,25 +4,33 @@ var path = require('path');
 var parseArgs = require('minimist');
 var msee = require('msee');
 var fs = require('fs');
+var template = require('string-template');
 
 var installModule = require('./install.js');
 var buildChangelog = require('../index.js');
 var readChangelog = require('../changelog/read.js');
 
-function printHelp() {
+function printHelp(opts) {
+    opts = opts || {};
+
     var loc = path.join(__dirname, 'usage.md');
     var content = fs.readFileSync(loc, 'utf8');
+
+    content = template(content, {
+        cmd: opts.cmd || 'build-changelog'
+    });
+
     return console.log(msee.parse(content, {
         paragraphStart: '\n'
     }));
 }
 
 function main(opts) {
-    if (opts.h || opts.help) {
+    var command = opts._[0];
+
+    if (opts.h || opts.help || command === 'help') {
         return printHelp();
     }
-
-    var command = opts._[0];
 
     if (!opts.folder) {
         opts.folder = process.cwd();

--- a/bin/usage.md
+++ b/bin/usage.md
@@ -1,4 +1,4 @@
-# build-changelog [options]
+# {cmd} [options]
 
 Builds the CHANGELOG file and commits it to git. Either creates
   a new CHANGELOG file or appends to the top of an existing one.
@@ -14,18 +14,18 @@ Options:
  - `--folder` defaults to `process.cwd()`
  - `--filename` defaults to `CHANGELOG`
 
-## `build-changelog --help`
+## `{cmd} --help`
 
 Prints this message
 
-## `build-changelog install`
+## `{cmd} install`
 
 Will write a `changelog` script to your `package.json` file.
 
 ```json
 {
     "scripts": {
-        "changelog": "build-changelog"
+        "changelog": "{cmd}"
     }
 }
 ```
@@ -33,15 +33,15 @@ Will write a `changelog` script to your `package.json` file.
 Options:
     --folder    sets the folder location of the package.json file
 
-## `build-changelog version [<newversion> | major | minor | patch]`
+## `{cmd} version [<newversion> | major | minor | patch]`
 
-This is the same as `build-changelog` except allows you to set
-  a specific version. `build-changelog` will by default bump
+This is the same as `{cmd}` except allows you to set
+  a specific version. `{cmd}` will by default bump
   the minor version number.
 
 This is an alternative to `npm version`, the main addition is
   changing the CHANGELOG file.
 
-## `build-changelog read <file>`
+## `{cmd} read <file>`
 
 Reads and parses a changelog file and writes JSON to stdout

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "semver": "^2.2.1",
     "safe-json-parse": "^1.0.1",
     "minimist": "0.0.8",
-    "msee": "^0.1.1"
+    "msee": "^0.1.1",
+    "string-template": "~0.1.3"
   },
   "devDependencies": {
     "jshint": "2.4.2",


### PR DESCRIPTION
This allows other tools to shell out to this tool but change the cmd in the help format. Namely `playdoh changelog`

cc @dfellis @sh1mmer 
