### PR TITLE
Default to bumping patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ build-changelog := (folder: String | {
     folder: String,
     nextVersion?: String,
     major?: Boolean,
+    minor?: Boolean,
     patch?: Boolean,
     filename?: String,
     logFlags?: String
@@ -173,14 +174,19 @@ When set to a valid semver string this version will be used to
 #### `options.major`
 
 This flag defaults to `false`. When set to `true` the major
-  version number will be increased instead of the minor version
+  version number will be increased instead of the patch version
+  number.
+
+#### `options.minor`
+
+This flag defaults to `false`. When set to `true` the minor
+  version number will be increased instead of the patch version
   number.
 
 #### `options.patch`
 
-This flag defaults to `false`. When set to `true` the patch
-  version number will be increased instead of the minor version
-  number.
+This flag defaults to `true`. When set to `true` the patch
+  version number will be increased.
 
 #### `options.logFlags`
 

--- a/bin/usage.md
+++ b/bin/usage.md
@@ -5,11 +5,13 @@ Builds the CHANGELOG file and commits it to git. Either creates
 
 Options:
     --major            bump the major version number
+    --minor            bump the minor version number
     --log-flags=[str]  extra flags to pass to `git log`
     --folder=[str]     sets the git repo & CHANGELOG location
     --filename=[str]   the filename we write the CHANGELOG too
 
  - `--major` defaults to `false`
+ - `--minor` defaults to `false`
  - `--log-flags` defaults to `--decorate --oneline`
  - `--folder` defaults to `process.cwd()`
  - `--filename` defaults to `CHANGELOG`

--- a/docs.mli
+++ b/docs.mli
@@ -53,6 +53,7 @@ type ChangelogOptions := {
     nextVersion: String,
     logFlags: String,
     major: Boolean,
+    minor: Boolean,
     patch: Boolean
 }
 
@@ -72,6 +73,7 @@ build-changelog := (folder: String | {
     folder: String,
     nextVersion?: String,
     major?: Boolean,
+    minor?: Boolean,
     patch?: Boolean,
     filename?: String,
     logFlags?: String

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var commitChanges = require('./tasks/commit-changes.js');
 
 var defaults = {
     major: false,
+    minor: false,
+    patch: true,
     logFlags: '--decorate --oneline',
     filename: 'CHANGELOG'
 };

--- a/tasks/compute-version.js
+++ b/tasks/compute-version.js
@@ -12,11 +12,11 @@ function createNextVersion(currentVersion, opts) {
         version.major++;
         version.minor = 0;
         version.patch = 0;
-    } else if (opts.patch) {
-        version.patch++;
-    } else {
+    } else if (opts.minor) {
         version.minor++;
         version.patch = 0;
+    } else if (opts.patch) {
+        version.patch++;
     }
 
     return version.format();

--- a/test/does-patch.js
+++ b/test/does-patch.js
@@ -1,0 +1,31 @@
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+
+var initRepo = require('./lib/init-repo.js');
+var buildChangelog = require('../index.js');
+
+var folder = path.join(__dirname, 'repo');
+
+test('run build-changelog & verify patch', initRepo(__dirname, {
+    'repo': {
+        'package.json': '{ "version": "0.1.0" }',
+        'index.js': 'module.exports = 42;'
+    }
+}, function (assert) {
+    buildChangelog({ folder: folder }, function (err, nextVersion) {
+        assert.ifError(err);
+        assert.equal(nextVersion, '0.1.1');
+
+        var loc = path.join(folder, 'package.json');
+        fs.readFile(loc, 'utf8', function (err, str) {
+            assert.ifError(err);
+
+            var json = JSON.parse(str);
+
+            assert.equal(json.version, '0.1.1');
+
+            assert.end();
+        });
+    });
+}));

--- a/test/fresh-repo.js
+++ b/test/fresh-repo.js
@@ -20,7 +20,7 @@ test('run build-changelog on fresh repo', initRepo(__dirname, {
 }, function (assert) {
     buildChangelog({ folder: folder }, function (err, nextVersion) {
         assert.ifError(err);
-        assert.equal(nextVersion, '0.2.0');
+        assert.equal(nextVersion, '0.1.1');
 
         parallel({
             log: exec.bind(null, 'git log --oneline', {
@@ -43,16 +43,16 @@ test('run build-changelog on fresh repo', initRepo(__dirname, {
 
             var logLines = log.trim().split('\n');
             assert.equal(logLines.length, 2);
-            assert.notEqual(logLines[0].indexOf('0.2.0'), -1);
+            assert.notEqual(logLines[0].indexOf('0.1.1'), -1);
             assert.notEqual(logLines[1].indexOf('initial commit'), -1);
 
             assert.notEqual(diff.indexOf('new file mode'), -1);
 
             assert.equal(
                 JSON.parse(String(data.package)).version,
-                '0.2.0');
+                '0.1.1');
 
-            assert.notEqual(data.diff2.indexOf('0.2.0'), -1);
+            assert.notEqual(data.diff2.indexOf('0.1.1'), -1);
 
             assert.ok(changelog);
 
@@ -64,7 +64,7 @@ test('run build-changelog on fresh repo', initRepo(__dirname, {
             var header = chunk.header;
 
             assert.equal(header.date, formatDate('yyyy-MM-dd'));
-            assert.equal(header.version, '0.2.0');
+            assert.equal(header.version, '0.1.1');
             assert.ok(header.commit);
 
             var lines = chunk.lines;

--- a/test/index.js
+++ b/test/index.js
@@ -10,3 +10,4 @@ test('buildChangelog is a function', function (assert) {
 
 require('./fresh-repo.js');
 require('./second-call.js');
+require('./does-patch.js');

--- a/test/second-call.js
+++ b/test/second-call.js
@@ -42,7 +42,7 @@ test('run build-changelog twice', setupRepo(__dirname, {
 }, function (assert) {
     buildChangelog({ folder: folder }, function (err, nextVersion) {
         assert.ifError(err);
-        assert.equal(nextVersion, '0.3.0');
+        assert.equal(nextVersion, '0.1.2');
 
         parallel({
             log: exec.bind(null, 'git log --oneline', {
@@ -57,9 +57,9 @@ test('run build-changelog twice', setupRepo(__dirname, {
 
             var logLines = data.log.trim().split('\n');
             assert.equal(logLines.length, 4);
-            assert.notEqual(logLines[0].indexOf('0.3.0'), -1);
+            assert.notEqual(logLines[0].indexOf('0.1.2'), -1);
             assert.notEqual(logLines[1].indexOf('an extra commit'), -1);
-            assert.notEqual(logLines[2].indexOf('0.2.0'), -1);
+            assert.notEqual(logLines[2].indexOf('0.1.1'), -1);
             assert.notEqual(logLines[3].indexOf('initial commit'), -1);
 
             var diff = data.diff;
@@ -74,8 +74,8 @@ test('run build-changelog twice', setupRepo(__dirname, {
             var chunk1 = changelog.chunks[0];
             var chunk2 = changelog.chunks[1];
 
-            assert.equal(chunk2.header.version, '0.2.0');
-            assert.equal(chunk1.header.version, '0.3.0');
+            assert.equal(chunk2.header.version, '0.1.1');
+            assert.equal(chunk1.header.version, '0.1.2');
 
             var lines1 = chunk1.lines;
             var lines2 = chunk2.lines;
@@ -89,9 +89,9 @@ test('run build-changelog twice', setupRepo(__dirname, {
             assert.equal(lines1[0].message, 'an extra commit');
             assert.deepEqual(lines1[0].decorations,
                 ['HEAD', 'master']);
-            assert.equal(lines1[1].message, '0.2.0');
+            assert.equal(lines1[1].message, '0.1.1');
             assert.deepEqual(lines1[1].decorations,
-                ['tag: v0.2.0']);
+                ['tag: v0.1.1']);
 
             assert.end();
         });


### PR DESCRIPTION
We had an issue this morning during a deploy where we bumped the minor version on a release branch instead of the main branch.

This meant we couldn't bump the minor on the main branch because the tag existed.

The solution is to bump the patch by default so that bumps on the release branch are patch bumps then to bump the minor explicitly when we release the main branch thus tagging over the patch bump

cc @jcorbin @squamos 
