### PR TITLE
customize install more

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -56,7 +56,7 @@ function main(opts) {
                 throw err;
             }
 
-            console.log('added build-changelog to package.json');
+            console.log('added %s to package.json', opts.cmd);
         });
     }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -15,6 +15,7 @@ function installModule(opts, cb) {
 
     opts.cmd = opts.cmd || 'build-changelog';
     opts.packageVersion = opts.packageVersion || '^' + version;
+    opts.moduleName = opts.moduleName || 'build-changelog';
 
     transactJsonFile(file, function (package) {
         package.scripts = package.scripts || {};
@@ -32,7 +33,8 @@ function installModule(opts, cb) {
 
         if (!opts.onlyScripts) {
             package.devDependencies = package.devDependencies || {};
-            package.devDependencies[opts.cmd] = opts.packageVersion;
+            package.devDependencies[opts.moduleName] =
+                opts.packageVersion;
         }
 
         return package;


### PR DESCRIPTION
This allows `play-doh` to customize the output of `build-changelog install` more.

cc @sh1mmer 
