### PR TITLE
Add a hotfix option to changelog

### DIFF
--- a/bin/usage.md
+++ b/bin/usage.md
@@ -6,6 +6,7 @@ Builds the CHANGELOG file and commits it to git. Either creates
 Options:
     --major            bump the major version number
     --minor            bump the minor version number
+    --hotfix=[str]     bump the release version with your message
     --log-flags=[str]  extra flags to pass to `git log`
     --folder=[str]     sets the git repo & CHANGELOG location
     --filename=[str]   the filename we write the CHANGELOG too
@@ -15,6 +16,7 @@ Options:
  - `--log-flags` defaults to `--decorate --oneline`
  - `--folder` defaults to `process.cwd()`
  - `--filename` defaults to `CHANGELOG`
+ - `--hotfix` defaults to `''`
 
 ## `{cmd} --help`
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var defaults = {
     major: false,
     minor: false,
     patch: true,
+    hotfix: '',
     logFlags: '--decorate --first-parent --oneline',
     filename: 'CHANGELOG'
 };

--- a/tasks/compute-version.js
+++ b/tasks/compute-version.js
@@ -15,6 +15,8 @@ function createNextVersion(currentVersion, opts) {
     } else if (opts.minor) {
         version.minor++;
         version.patch = 0;
+    } else if (opts.hotfix) {
+        version.prerelease = [opts.hotfix];
     } else if (opts.patch) {
         version.patch++;
     }


### PR DESCRIPTION
This allows `playdoh changelog --hotfix=branch-name` to not bump
  the patch but instead create `vx.y.z-branch-name`.

cc @sh1mmer
